### PR TITLE
Update pubspec.yaml to support Null safety

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   flare_flutter: ^2.0.3
-  lottie: ^0.7.0+1
+  lottie: ^1.0.1
   vector_math: ^2.0.8
 
 dev_dependencies:


### PR DESCRIPTION
Updated package dependencies of lottie so cool_alert is  compatible with other null safe packages 


Because image >=3.0.0-nullsafety.0 <3.0.1 depends on archive ^3.0.0-nullsafety.0 and no versions of image match >3.0.1 <4.0.0, image >=3.0.0-nullsafety.0 <3.0.1-∞ or >3.0.1 <4.0.0 requires archive ^3.0.0-nullsafety.0.
And because image 3.0.1 depends on archive ^3.0.0, image ^3.0.0-nullsafety.0 requires archive ^3.0.0-nullsafety.0.
Because no versions of flutter_launcher_icons match >0.9.0 <0.10.0 and flutter_launcher_icons 0.9.0 depends on image ^3.0.0-nullsafety.0, flutter_launcher_icons ^0.9.0 requires image ^3.0.0-nullsafety.0.

And because cool_alert >=1.0.2 depends on lottie ^0.7.0+1 which depends on archive ^2.0.0, flutter_launcher_icons ^0.9.0 is incompatible with cool_alert >=1.0.2.